### PR TITLE
Random: clarify the top text

### DIFF
--- a/src/views/Random.vue
+++ b/src/views/Random.vue
@@ -8,7 +8,7 @@
           Random image
         </h1>
         <p class="mt-1 max-w-2xl text-sm text-gray-500 dark:text-gray-400">
-          Here's a random image from any collection.
+          Here's a random image from one of the collections.
         </p>
       </div>
       <button

--- a/src/views/Random.vue
+++ b/src/views/Random.vue
@@ -8,7 +8,7 @@
           Random image
         </h1>
         <p class="mt-1 max-w-2xl text-sm text-gray-500 dark:text-gray-400">
-          Here's a random image from the collections.
+          Here's a random image from any collection.
         </p>
       </div>
       <button


### PR DESCRIPTION
This PR changes the text at the top of the random page to be less ambiguous. "the collections" referred to many specific collections, while only one image was shown, which didn't make much sense.